### PR TITLE
Fix company dropdown and implement admin-only authentication

### DIFF
--- a/app/components/dashboard/AdminClientToggle.tsx
+++ b/app/components/dashboard/AdminClientToggle.tsx
@@ -1,0 +1,80 @@
+'use client'
+
+import React, { useState, useEffect } from 'react'
+import { Client } from '@/lib/supabase/types'
+
+interface AdminClientToggleProps {
+  clients: Client[]
+  selectedClientUuid: string
+  selectedClient: Client | null
+  onClientChange: (client: Client) => void
+}
+
+export function AdminClientToggle({ 
+  clients, 
+  selectedClientUuid, 
+  selectedClient, 
+  onClientChange 
+}: AdminClientToggleProps) {
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false)
+
+  // Handle clicking outside dropdown to close it
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      const target = event.target as HTMLElement
+      if (!target.closest('#client-dropdown-container')) {
+        setIsDropdownOpen(false)
+      }
+    }
+
+    if (isDropdownOpen) {
+      document.addEventListener('mousedown', handleClickOutside)
+    }
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside)
+    }
+  }, [isDropdownOpen])
+
+  return (
+    <div id="client-dropdown-container" className="relative">
+      <button
+        onClick={() => setIsDropdownOpen(!isDropdownOpen)}
+        className="p-2 text-gray-600 hover:text-gray-900 hover:bg-gray-100 rounded-md transition-colors"
+        aria-label="Switch company"
+      >
+        <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+      
+      {isDropdownOpen && (
+        <div className="absolute left-0 mt-2 w-56 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 z-50">
+          <div className="py-1" role="menu" aria-orientation="vertical">
+            <div className="px-4 py-2 text-xs text-gray-500 font-semibold uppercase tracking-wider">
+              Switch Company
+            </div>
+            {clients.map((client) => (
+              <button
+                key={client.uuid}
+                onClick={() => {
+                  onClientChange(client)
+                  setIsDropdownOpen(false)
+                }}
+                className={`w-full text-left px-4 py-2 text-sm hover:bg-gray-100 ${
+                  selectedClientUuid === client.uuid ? 'bg-gray-50 font-medium' : ''
+                }`}
+                role="menuitem"
+              >
+                {client.name}
+                {selectedClientUuid === client.uuid && (
+                  <span className="ml-2 text-primary-600">✓</span>
+                )}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -19,6 +19,7 @@ export default function DashboardPage() {
   const [clients, setClients] = useState<Client[]>([])
   const [selectedClientUuid, setSelectedClientUuid] = useState<string>('')
   const [selectedClient, setSelectedClient] = useState<Client | null>(null)
+  const [isAdmin, setIsAdmin] = useState(false)
   const [isLoading, setIsLoading] = useState(true)
   const [sortField, setSortField] = useState<SortField>('name')
   const [sortDirection, setSortDirection] = useState<SortDirection>('asc')
@@ -52,6 +53,18 @@ export default function DashboardPage() {
         }
         
         setUserData(userData)
+        
+        // Check if user is an admin
+        const { data: adminData, error: adminError } = await supabase
+          .from('user_admins')
+          .select('email, active')
+          .eq('email', session.user.email)
+          .eq('active', true)
+          .single()
+        
+        if (!adminError && adminData) {
+          setIsAdmin(true)
+        }
         
         // Initialize organizations as empty - will be loaded after client selection
         setOrganizations([])
@@ -265,7 +278,7 @@ export default function DashboardPage() {
                   {selectedClient.name}
                 </h1>
               )}
-              {userData?.client_uuid === '36fee78e-9bac-4443-9339-6f53003d3250' && (
+              {isAdmin && (
                 <AdminClientToggle
                   clients={clients}
                   selectedClientUuid={selectedClientUuid}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -23,6 +23,7 @@ export default function DashboardPage() {
   const [sortDirection, setSortDirection] = useState<SortDirection>('asc')
   const [expandedRows, setExpandedRows] = useState<Set<string>>(new Set())
   const [orgDetails, setOrgDetails] = useState<Record<string, (ClientOrganizationHistory & { positions?: any[] }) | null>>({})
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false)
   const router = useRouter()
   const supabase = createClientComponentClient()
 
@@ -143,6 +144,24 @@ export default function DashboardPage() {
     await supabase.auth.signOut()
     router.push('/')
   }
+
+  // Handle clicking outside dropdown to close it
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      const target = event.target as HTMLElement
+      if (!target.closest('#client-dropdown-container')) {
+        setIsDropdownOpen(false)
+      }
+    }
+
+    if (isDropdownOpen) {
+      document.addEventListener('mousedown', handleClickOutside)
+    }
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside)
+    }
+  }, [isDropdownOpen])
 
   // Sorting logic
   const sortedOrganizations = useMemo(() => {
@@ -265,29 +284,46 @@ export default function DashboardPage() {
                 </h1>
               )}
               {userData?.client_uuid === '36fee78e-9bac-4443-9339-6f53003d3250' && (
-                <select
-                  id="client-select"
-                  value={selectedClientUuid}
-                  onChange={(e) => {
-                    const newClientUuid = e.target.value
-                    setSelectedClientUuid(newClientUuid)
-                    
-                    // Also update selectedClient object for display purposes
-                    const client = clients.find(c => c.uuid === newClientUuid)
-                    setSelectedClient(client || null)
-                    
-                    // Dashboard will automatically refresh via useEffect on selectedClientUuid change
-                    // This will reload organizations and any other client-specific data
-                  }}
-                  className="block w-48 px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-primary-500 focus:border-primary-500 sm:text-sm bg-white"
-                >
-                  <option value="">Select a client...</option>
-                  {clients.map((client) => (
-                    <option key={client.uuid} value={client.uuid}>
-                      {client.name}
-                    </option>
-                  ))}
-                </select>
+                <div id="client-dropdown-container" className="relative">
+                  <button
+                    onClick={() => setIsDropdownOpen(!isDropdownOpen)}
+                    className="p-2 text-gray-600 hover:text-gray-900 hover:bg-gray-100 rounded-md transition-colors"
+                    aria-label="Switch company"
+                  >
+                    <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                    </svg>
+                  </button>
+                  
+                  {isDropdownOpen && (
+                    <div className="absolute left-0 mt-2 w-56 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 z-50">
+                      <div className="py-1" role="menu" aria-orientation="vertical">
+                        <div className="px-4 py-2 text-xs text-gray-500 font-semibold uppercase tracking-wider">
+                          Switch Company
+                        </div>
+                        {clients.map((client) => (
+                          <button
+                            key={client.uuid}
+                            onClick={() => {
+                              setSelectedClientUuid(client.uuid)
+                              setSelectedClient(client)
+                              setIsDropdownOpen(false)
+                            }}
+                            className={`w-full text-left px-4 py-2 text-sm hover:bg-gray-100 ${
+                              selectedClientUuid === client.uuid ? 'bg-gray-50 font-medium' : ''
+                            }`}
+                            role="menuitem"
+                          >
+                            {client.name}
+                            {selectedClientUuid === client.uuid && (
+                              <span className="ml-2 text-primary-600">✓</span>
+                            )}
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                </div>
               )}
             </div>
             <div className="flex items-center space-x-4">

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -258,10 +258,37 @@ export default function DashboardPage() {
       <header className="bg-white shadow-sm border-b border-gray-200">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between items-center h-16">
-            <div className="flex items-center">
-              <h1 className="text-2xl font-light tracking-wide text-red-600">
-                External View
-              </h1>
+            <div className="flex items-center space-x-4">
+              {selectedClient && (
+                <h1 className="text-2xl font-bold tracking-wide text-gray-900">
+                  {selectedClient.name}
+                </h1>
+              )}
+              {userData?.client_uuid === '36fee78e-9bac-4443-9339-6f53003d3250' && (
+                <select
+                  id="client-select"
+                  value={selectedClientUuid}
+                  onChange={(e) => {
+                    const newClientUuid = e.target.value
+                    setSelectedClientUuid(newClientUuid)
+                    
+                    // Also update selectedClient object for display purposes
+                    const client = clients.find(c => c.uuid === newClientUuid)
+                    setSelectedClient(client || null)
+                    
+                    // Dashboard will automatically refresh via useEffect on selectedClientUuid change
+                    // This will reload organizations and any other client-specific data
+                  }}
+                  className="block w-48 px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-primary-500 focus:border-primary-500 sm:text-sm bg-white"
+                >
+                  <option value="">Select a client...</option>
+                  {clients.map((client) => (
+                    <option key={client.uuid} value={client.uuid}>
+                      {client.name}
+                    </option>
+                  ))}
+                </select>
+              )}
             </div>
             <div className="flex items-center space-x-4">
               <div className="text-sm text-gray-600">
@@ -280,44 +307,6 @@ export default function DashboardPage() {
 
       {/* Main Content */}
       <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-
-        {/* Client Selection Header */}
-        <div className="flex justify-between items-center mb-8">
-          <div>
-            {selectedClient && (
-              <h1 className="text-2xl font-bold tracking-wide text-gray-900">
-                {selectedClient.name}
-              </h1>
-            )}
-          </div>
-          {userData?.client_uuid === '36fee78e-9bac-4443-9339-6f53003d3250' && (
-            <div className="flex-shrink-0">
-              <select
-                id="client-select"
-                value={selectedClientUuid}
-                onChange={(e) => {
-                  const newClientUuid = e.target.value
-                  setSelectedClientUuid(newClientUuid)
-                  
-                  // Also update selectedClient object for display purposes
-                  const client = clients.find(c => c.uuid === newClientUuid)
-                  setSelectedClient(client || null)
-                  
-                  // Dashboard will automatically refresh via useEffect on selectedClientUuid change
-                  // This will reload organizations and any other client-specific data
-                }}
-                className="block w-48 px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-primary-500 focus:border-primary-500 sm:text-sm bg-white"
-              >
-                <option value="">Select a client...</option>
-                {clients.map((client) => (
-                  <option key={client.uuid} value={client.uuid}>
-                    {client.name}
-                  </option>
-                ))}
-              </select>
-            </div>
-          )}
-        </div>
 
         {/* Organizations Section */}
         <div className="bg-white rounded-lg shadow-sm border border-gray-200">

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/navigation'
 import { User, Organization, Client, ClientOrganizationHistory } from '@/lib/supabase/types'
 import { SortField, SortDirection } from '@/lib/types/dashboard'
 import { formatCurrency, formatDate, formatFieldValue } from '@/app/utils/formatters'
+import { AdminClientToggle } from '@/app/components/dashboard/AdminClientToggle'
 
 
 
@@ -23,7 +24,6 @@ export default function DashboardPage() {
   const [sortDirection, setSortDirection] = useState<SortDirection>('asc')
   const [expandedRows, setExpandedRows] = useState<Set<string>>(new Set())
   const [orgDetails, setOrgDetails] = useState<Record<string, (ClientOrganizationHistory & { positions?: any[] }) | null>>({})
-  const [isDropdownOpen, setIsDropdownOpen] = useState(false)
   const router = useRouter()
   const supabase = createClientComponentClient()
 
@@ -144,24 +144,6 @@ export default function DashboardPage() {
     await supabase.auth.signOut()
     router.push('/')
   }
-
-  // Handle clicking outside dropdown to close it
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      const target = event.target as HTMLElement
-      if (!target.closest('#client-dropdown-container')) {
-        setIsDropdownOpen(false)
-      }
-    }
-
-    if (isDropdownOpen) {
-      document.addEventListener('mousedown', handleClickOutside)
-    }
-
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside)
-    }
-  }, [isDropdownOpen])
 
   // Sorting logic
   const sortedOrganizations = useMemo(() => {
@@ -284,46 +266,15 @@ export default function DashboardPage() {
                 </h1>
               )}
               {userData?.client_uuid === '36fee78e-9bac-4443-9339-6f53003d3250' && (
-                <div id="client-dropdown-container" className="relative">
-                  <button
-                    onClick={() => setIsDropdownOpen(!isDropdownOpen)}
-                    className="p-2 text-gray-600 hover:text-gray-900 hover:bg-gray-100 rounded-md transition-colors"
-                    aria-label="Switch company"
-                  >
-                    <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-                    </svg>
-                  </button>
-                  
-                  {isDropdownOpen && (
-                    <div className="absolute left-0 mt-2 w-56 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 z-50">
-                      <div className="py-1" role="menu" aria-orientation="vertical">
-                        <div className="px-4 py-2 text-xs text-gray-500 font-semibold uppercase tracking-wider">
-                          Switch Company
-                        </div>
-                        {clients.map((client) => (
-                          <button
-                            key={client.uuid}
-                            onClick={() => {
-                              setSelectedClientUuid(client.uuid)
-                              setSelectedClient(client)
-                              setIsDropdownOpen(false)
-                            }}
-                            className={`w-full text-left px-4 py-2 text-sm hover:bg-gray-100 ${
-                              selectedClientUuid === client.uuid ? 'bg-gray-50 font-medium' : ''
-                            }`}
-                            role="menuitem"
-                          >
-                            {client.name}
-                            {selectedClientUuid === client.uuid && (
-                              <span className="ml-2 text-primary-600">✓</span>
-                            )}
-                          </button>
-                        ))}
-                      </div>
-                    </div>
-                  )}
-                </div>
+                <AdminClientToggle
+                  clients={clients}
+                  selectedClientUuid={selectedClientUuid}
+                  selectedClient={selectedClient}
+                  onClientChange={(client) => {
+                    setSelectedClientUuid(client.uuid)
+                    setSelectedClient(client)
+                  }}
+                />
               )}
             </div>
             <div className="flex items-center space-x-4">

--- a/app/hooks/useAuth.ts
+++ b/app/hooks/useAuth.ts
@@ -60,7 +60,7 @@ export const useAuth = (): AuthState => {
           // Create minimal user data for admin
           const minimalUserData: User = {
             id: session.user.id,
-            email: session.user.email,
+            email: session.user.email!,  // Email is guaranteed to exist after OAuth
             company: 'Admin',
             client_uuid: '', // Admins don't have a default client
             active: true,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -24,6 +24,19 @@ export default function HomePage() {
         
         if (allowedUser) {
           router.push('/dashboard')
+          return
+        }
+        
+        // If not in users table, check if they're an admin
+        const { data: adminUser } = await supabase
+          .from('user_admins')
+          .select('*')
+          .eq('email', session.user.email)
+          .eq('active', true)
+          .single()
+        
+        if (adminUser) {
+          router.push('/dashboard')
         }
       }
     }

--- a/supabase/migrations/20250910_create_user_admins_table.sql
+++ b/supabase/migrations/20250910_create_user_admins_table.sql
@@ -1,0 +1,94 @@
+-- Migration: Create user_admins table for admin authorization
+-- Date: 2025-09-10
+-- Purpose: Store admin users separately for better security and audit trail
+
+-- ============================================================================
+-- STEP 1: CREATE TABLE
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS user_admins (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  email VARCHAR(255) UNIQUE NOT NULL,
+  granted_by VARCHAR(255),
+  granted_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  active BOOLEAN DEFAULT true,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- ============================================================================
+-- STEP 2: INSERT INITIAL ADMIN USERS
+-- ============================================================================
+INSERT INTO user_admins (email, granted_by, active) VALUES
+  ('jebory@gmail.com', 'system', true),
+  ('vikassood@gmail.com', 'system', true)
+ON CONFLICT (email) DO NOTHING;
+
+-- ============================================================================
+-- STEP 3: CREATE INDEXES
+-- ============================================================================
+CREATE INDEX IF NOT EXISTS idx_user_admins_email ON user_admins(email);
+CREATE INDEX IF NOT EXISTS idx_user_admins_active ON user_admins(active);
+
+-- ============================================================================
+-- STEP 4: ENABLE ROW LEVEL SECURITY
+-- ============================================================================
+ALTER TABLE user_admins ENABLE ROW LEVEL SECURITY;
+
+-- ============================================================================
+-- STEP 5: CREATE RLS POLICIES
+-- ============================================================================
+-- Allow all authenticated users to check if an email is admin
+-- This is needed for the dashboard to check admin status
+CREATE POLICY "Allow users to check admin status" 
+ON user_admins 
+FOR SELECT 
+USING (true);
+
+-- Only admins can insert new admins
+CREATE POLICY "Only admins can create admins" 
+ON user_admins 
+FOR INSERT 
+WITH CHECK (
+  EXISTS (
+    SELECT 1 FROM user_admins 
+    WHERE email = auth.jwt() ->> 'email' 
+    AND active = true
+  )
+);
+
+-- Only admins can update admin records
+CREATE POLICY "Only admins can update admins" 
+ON user_admins 
+FOR UPDATE 
+USING (
+  EXISTS (
+    SELECT 1 FROM user_admins 
+    WHERE email = auth.jwt() ->> 'email' 
+    AND active = true
+  )
+);
+
+-- No one can delete admin records (for audit trail)
+-- If you need to revoke access, set active = false
+CREATE POLICY "No delete on admin records" 
+ON user_admins 
+FOR DELETE 
+USING (false);
+
+-- ============================================================================
+-- STEP 6: ADD COMMENTS
+-- ============================================================================
+COMMENT ON TABLE user_admins IS 'Stores admin users who can switch between all client organizations';
+COMMENT ON COLUMN user_admins.email IS 'Email address of the admin user';
+COMMENT ON COLUMN user_admins.granted_by IS 'Who granted admin access to this user';
+COMMENT ON COLUMN user_admins.granted_at IS 'When admin access was granted';
+COMMENT ON COLUMN user_admins.active IS 'Whether this admin is currently active';
+
+-- ============================================================================
+-- VERIFICATION
+-- ============================================================================
+-- After this migration:
+-- 1. user_admins table will exist with two admin users
+-- 2. RLS policies ensure only admins can modify admin list
+-- 3. All users can check if an email is admin (needed for app)
+-- 4. Admin records cannot be deleted (audit trail)

--- a/supabase/migrations/20250910_remove_admins_from_users_table.sql
+++ b/supabase/migrations/20250910_remove_admins_from_users_table.sql
@@ -1,0 +1,18 @@
+-- Migration: Remove admin users from users table
+-- Date: 2025-09-10
+-- Purpose: Clean up users table to only contain actual client users
+
+-- ============================================================================
+-- STEP 1: DELETE ADMIN USERS FROM USERS TABLE
+-- ============================================================================
+-- Remove admin users who are now managed through user_admins table
+DELETE FROM users 
+WHERE email IN ('jebory@gmail.com', 'vikassood@gmail.com');
+
+-- ============================================================================
+-- VERIFICATION
+-- ============================================================================
+-- After this migration:
+-- 1. Admin users will only exist in user_admins table
+-- 2. Users table will only contain actual client users
+-- 3. Admins can still login and will be authenticated via user_admins table


### PR DESCRIPTION
## Summary
- Moved company dropdown from sidebar to header with icon-triggered menu
- Implemented database-driven admin authorization using user_admins table
- Allow admin users to authenticate without being in users table

## Changes
1. **UI Improvements**
   - Removed "External View" text from header
   - Display selected client name in header
   - Created AdminClientToggle component with dropdown menu
   - Toggle only visible to admin users

2. **Admin Authentication**
   - Created user_admins table for managing admin users
   - Updated auth flow to check both users and user_admins tables
   - Admins can login without being in users table
   - Auto-select first client for admin users

3. **Database Cleanup**
   - Added migration to remove admin emails from users table
   - Keep users table clean with only actual client users

## Test plan
- [x] Admin users can login with only user_admins entry
- [x] Regular users still authenticate normally
- [x] Admin toggle only visible to users in user_admins table
- [x] Admins can switch between all clients

🤖 Generated with [Claude Code](https://claude.ai/code)